### PR TITLE
Fire forget  publishing of observations

### DIFF
--- a/UnitTests/ScientistTests.cs
+++ b/UnitTests/ScientistTests.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using GitHub;

--- a/UnitTests/ScientistTests.cs
+++ b/UnitTests/ScientistTests.cs
@@ -134,14 +134,5 @@ public class TheScientistClass
             Assert.True(observation.ControlDuration.Ticks > 0);
             Assert.True(observation.CandidateDuration.Ticks > 0);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public string GetCurrentMethod()
-        {
-            StackTrace st = new StackTrace();
-            StackFrame sf = st.GetFrame(1);
-
-            return sf.GetMethod().Name;
-        }
     }
 }

--- a/UnitTests/ScientistTests.cs
+++ b/UnitTests/ScientistTests.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using GitHub;
 using GitHub.Internals;
@@ -7,17 +10,19 @@ using NSubstitute;
 using UnitTests;
 using Xunit;
 
+using System.Reactive.Linq;
+
 public class TheScientistClass
 {
     public class TheScienceMethod
     {
         [Fact]
-        public void RunsBothBranchesOfTheExperimentAndReportsSuccess()
+        public async void RunsBothBranchesOfTheExperimentAndReportsSuccess()
         {
-            var mock = Substitute.For< IControlCandidate<int>>();
+            var mock = Substitute.For<IControlCandidate<int>>();
             mock.Control().Returns(42);
             mock.Candidate().Returns(42);
-           
+
 
             var result = Scientist.Science<int>("success", experiment =>
             {
@@ -28,7 +33,9 @@ public class TheScientistClass
             Assert.Equal(42, result);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "success").Success);
+
+            var observation = await TestHelper.ObservationsGeneratedInThisMethod().FirstAsync();
+            Assert.True(observation.Success);
         }
 
         [Fact]
@@ -37,9 +44,6 @@ public class TheScientistClass
             var mock = Substitute.For<IControlCandidateTask<int>>();
             mock.Control().Returns(Task.FromResult(42));
             mock.Candidate().Returns(Task.FromResult(43));
-           
-
-
 
             var result = await Scientist.ScienceAsync<int>("failure", experiment =>
             {
@@ -50,20 +54,25 @@ public class TheScientistClass
             Assert.Equal(42, result);
             await mock.Received().Control();
             await mock.Received().Candidate();
-            Assert.False(TestHelper.Observation.First(m => m.Name == "failure").Success);
+
+            var observation = await TestHelper.ObservationsGeneratedInThisMethod().FirstAsync();
+            Assert.False(observation.Success);
         }
 
         [Fact]
-        public void AllowsReturningNullFromControlOrTest()
+        public async void AllowsReturningNullFromControlOrTest()
         {
             var result = Scientist.Science<object>("failure", experiment =>
-            {
-                experiment.Use(() => null);
-                experiment.Try(() => null);
-            });
+                {
+                    experiment.Use(() => null);
+                    experiment.Try(() => null);
+                });
 
             Assert.Null(result);
-            Assert.True(TestHelper.Observation.First(m => m.Name == "failure").Success);
+
+            var observation = await TestHelper.ObservationsGeneratedInThisMethod().FirstAsync();
+
+            Assert.True(observation.Success);
         }
 
         [Fact]
@@ -77,7 +86,7 @@ public class TheScientistClass
         }
 
         [Fact]
-        public void RunsBothBranchesOfTheExperimentAndReportsSuccessWithDurations()
+        public async void RunsBothBranchesOfTheExperimentAndReportsSuccessWithDurations()
         {
             var mock = Substitute.For<IControlCandidate<int>>();
             mock.Control().Returns(42);
@@ -92,13 +101,15 @@ public class TheScientistClass
             Assert.Equal(42, result);
             mock.Received().Control();
             mock.Received().Candidate();
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "success").Success);
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "success").ControlDuration.Ticks > 0);
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "success").CandidateDuration.Ticks > 0);
+
+            var observation = await TestHelper.ObservationsGeneratedInThisMethod().FirstAsync();
+            Assert.True(observation.Success);
+            Assert.True(observation.ControlDuration.Ticks > 0);
+            Assert.True(observation.CandidateDuration.Ticks > 0);
         }
 
         [Fact]
-        public void AnExceptionReportsDuration()
+        public async void AnExceptionReportsDuration()
         {
             var candidateRan = false;
             var controlRan = false;
@@ -117,9 +128,20 @@ public class TheScientistClass
             Assert.Equal(42, result);
             Assert.True(candidateRan);
             Assert.True(controlRan);
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "failure").Success == false);
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "failure").ControlDuration.Ticks > 0);
-            Assert.True(((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations.First(m => m.Name == "failure").CandidateDuration.Ticks > 0);
+
+            var observation = await TestHelper.ObservationsGeneratedInThisMethod().FirstAsync();
+            Assert.True(observation.Success == false);
+            Assert.True(observation.ControlDuration.Ticks > 0);
+            Assert.True(observation.CandidateDuration.Ticks > 0);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string GetCurrentMethod()
+        {
+            StackTrace st = new StackTrace();
+            StackFrame sf = st.GetFrame(1);
+
+            return sf.GetMethod().Name;
         }
     }
 }

--- a/UnitTests/ScientistTests.cs
+++ b/UnitTests/ScientistTests.cs
@@ -15,7 +15,7 @@ public class TheScientistClass
     public class TheScienceMethod
     {
         [Fact]
-        public async void RunsBothBranchesOfTheExperimentAndReportsSuccess()
+        public async Task RunsBothBranchesOfTheExperimentAndReportsSuccess()
         {
             var mock = Substitute.For<IControlCandidate<int>>();
             mock.Control().Returns(42);
@@ -58,7 +58,7 @@ public class TheScientistClass
         }
 
         [Fact]
-        public async void AllowsReturningNullFromControlOrTest()
+        public async Task AllowsReturningNullFromControlOrTest()
         {
             var result = Scientist.Science<object>("failure", experiment =>
                 {
@@ -84,7 +84,7 @@ public class TheScientistClass
         }
 
         [Fact]
-        public async void RunsBothBranchesOfTheExperimentAndReportsSuccessWithDurations()
+        public async Task RunsBothBranchesOfTheExperimentAndReportsSuccessWithDurations()
         {
             var mock = Substitute.For<IControlCandidate<int>>();
             mock.Control().Returns(42);
@@ -107,7 +107,7 @@ public class TheScientistClass
         }
 
         [Fact]
-        public async void AnExceptionReportsDuration()
+        public async Task AnExceptionReportsDuration()
         {
             var candidateRan = false;
             var controlRan = false;

--- a/UnitTests/TestHelper.cs
+++ b/UnitTests/TestHelper.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
 using GitHub;
 using GitHub.Internals;
 
@@ -6,4 +9,10 @@ public static class TestHelper
 {
     public static IEnumerable<Observation> Observation =>
         ((InMemoryObservationPublisher)Scientist.ObservationPublisher).Observations;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static IQbservable<Observation> ObservationsGeneratedInThisMethod([CallerMemberName] string callingMethodName = "")
+    {
+        return Scientist.Observations.Where(w => w.CallingMethodName.Equals(callingMethodName));
+    }
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -39,6 +39,26 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Providers, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Rx-Providers.2.2.5\lib\net45\System.Reactive.Providers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="1.9.2.0" targetFramework="net452" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Providers" version="2.2.5" targetFramework="net452" />
   <package id="xunit" version="2.2.0-beta1-build3239" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0-beta1-build3239" targetFramework="net452" />

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Internals

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace GitHub.Internals
@@ -11,26 +13,59 @@ namespace GitHub.Internals
     internal class ExperimentInstance<T>
     {
         static Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);
-
+      
         readonly Func<Task<T>> _control;
         readonly Func<Task<T>> _candidate;
         readonly string _name;
+        private readonly string _callingmethodName;
 
-        public ExperimentInstance(string name, Func<T> control, Func<T> candidate)
+        public ExperimentInstance(string name, Func<T> control, Func<T> candidate, String callingmethodName = "")
         {
             _name = name;
+            _callingmethodName = callingmethodName;
             _control = () => Task.FromResult(control());
             _candidate = () => Task.FromResult(candidate());
+
+           
         }
 
-        public ExperimentInstance(string name, Func<Task<T>> control, Func<Task<T>> candidate)
+        public ExperimentInstance(string name, Func<Task<T>> control, Func<Task<T>> candidate, String callingmethodName = "")
         {
             _name = name;
             _control = control;
             _candidate = candidate;
+            _callingmethodName = callingmethodName;
         }
 
+     
+
         public async Task<T> Run()
+        {
+            ExperimentResult candidateResult;
+            ExperimentResult controlResult;
+
+            Tuple<ExperimentResult, ExperimentResult> result = await RunExperiments();
+            controlResult = result.Item1;
+            candidateResult = result.Item2;
+
+            // TODO: We need to compare that thrown exceptions are equivalent too https://github.com/github/scientist/blob/master/lib/scientist/observation.rb#L76
+            // TODO: We're going to have to be a bit more sophisticated about this.
+            bool success =
+                controlResult.Result == null && candidateResult.Result == null
+                || controlResult.Result != null && controlResult.Result.Equals(candidateResult.Result)
+                || controlResult.Result == null && candidateResult.Result != null;
+
+            // TODO: Get that duration!
+            var observation = new Observation(_name, success, controlResult.Duration, candidateResult.Duration, _callingmethodName);
+
+            
+            Scientist.PublishObservation(observation); 
+
+            if (controlResult.ThrownException != null) throw controlResult.ThrownException;
+            return controlResult.Result;
+        }
+
+        private async Task<Tuple<ExperimentResult, ExperimentResult>> RunExperiments()
         {
             // Randomize ordering...
             var runControlFirst = _random.Next(0, 2) == 0;
@@ -47,24 +82,13 @@ namespace GitHub.Internals
                 candidateResult = await Run(_candidate);
                 controlResult = await Run(_control);
             }
-
-            // TODO: We need to compare that thrown exceptions are equivalent too https://github.com/github/scientist/blob/master/lib/scientist/observation.rb#L76
-            // TODO: We're going to have to be a bit more sophisticated about this.
-            bool success =
-                controlResult.Result == null && candidateResult.Result == null
-                || controlResult.Result != null && controlResult.Result.Equals(candidateResult.Result)
-                || controlResult.Result == null && candidateResult.Result != null;
-
-            // TODO: Get that duration!
-            var observation = new Observation(_name, success, controlResult.Duration, candidateResult.Duration);
-
-            // TODO: Make this Fire and forget so we don't have to wait for this
-            // to complete before we return a result
-            await Scientist.ObservationPublisher.Publish(observation);
-
-            if (controlResult.ThrownException != null) throw controlResult.ThrownException;
-            return controlResult.Result;
+            return new Tuple<ExperimentResult, ExperimentResult>(controlResult, candidateResult);
         }
+
+       
+
+
+       
 
         static async Task<ExperimentResult> Run(Func<Task<T>> experimentCase)
         {

--- a/src/Scientist/Internals/ExperimentBuilder.cs
+++ b/src/Scientist/Internals/ExperimentBuilder.cs
@@ -6,12 +6,14 @@ namespace GitHub.Internals
     internal class Experiment<T> : IExperiment<T>, IExperimentAsync<T>
     {
         string _name;
+        private readonly string _callingmethodName;
         Func<Task<T>> _control;
         Func<Task<T>> _candidate;
 
-        public Experiment(string name)
+        public Experiment(string name, String callingmethodName = "")
         {
             _name = name;
+            _callingmethodName = callingmethodName;
         }
 
         public void Use(Func<Task<T>> control) { _control = control; }
@@ -25,7 +27,7 @@ namespace GitHub.Internals
 
         internal ExperimentInstance<T> Build()
         {
-            return new ExperimentInstance<T>(_name, _control, _candidate);
+            return new ExperimentInstance<T>(_name, _control, _candidate, _callingmethodName);
         }
     }
 }

--- a/src/Scientist/Observation.cs
+++ b/src/Scientist/Observation.cs
@@ -14,7 +14,7 @@ namespace GitHub
         /// </summary>
         /// <param name="name">The name of the experiment that was observed.</param>
         /// <param name="success">Whether the experiment was a success.</param>
-        /// <param name="controlDuration">The total duration for the controlled experiment.</param>
+        /// <param name="controlDuration">The total duration for the control experiment.</param>
         /// <param name="candidateDuration">The total duration for the candidate experiment.</param>
         /// <param name="callingMethodName">The name of the method where the experiment that was performed.</param>
         public Observation(string name, bool success, TimeSpan controlDuration, TimeSpan candidateDuration, string callingMethodName)
@@ -32,7 +32,7 @@ namespace GitHub
         public bool Success { get; }
         
         /// <summary>
-        /// Total duration of the controlled experiment.
+        /// Total duration of the control experiment.
         /// <see cref="IExperiment{T}.Use(Func{T})" /> or <see cref="IExperimentAsync{T}.Use(Func{Task{T}})" />.
         /// </summary>
         public TimeSpan ControlDuration { get; }

--- a/src/Scientist/Observation.cs
+++ b/src/Scientist/Observation.cs
@@ -1,6 +1,4 @@
-﻿using GitHub.Internals;
-using System;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace GitHub
 {

--- a/src/Scientist/Observation.cs
+++ b/src/Scientist/Observation.cs
@@ -16,12 +16,14 @@ namespace GitHub
         /// <param name="success">Whether the experiment was a success.</param>
         /// <param name="controlDuration">The total duration for the controlled experiment.</param>
         /// <param name="candidateDuration">The total duration for the candidate experiment.</param>
-        public Observation(string name, bool success, TimeSpan controlDuration, TimeSpan candidateDuration)
+        /// <param name="callingMethodName">The name of the method where the experiment that was performed.</param>
+        public Observation(string name, bool success, TimeSpan controlDuration, TimeSpan candidateDuration, string callingMethodName)
         {
             Name = name;
             Success = success;
             ControlDuration = controlDuration;
             CandidateDuration = candidateDuration;
+            CallingMethodName = callingMethodName;
         }
 
         /// <summary>
@@ -30,20 +32,25 @@ namespace GitHub
         public bool Success { get; }
         
         /// <summary>
-        /// Gets the total duration for the controlled experiment that was executed through
+        /// Total duration of the controlled experiment.
         /// <see cref="IExperiment{T}.Use(Func{T})" /> or <see cref="IExperimentAsync{T}.Use(Func{Task{T}})" />.
         /// </summary>
         public TimeSpan ControlDuration { get; }
         
         /// <summary>
-        /// Gets the total duration for the candidate experiment that was executed through
+        /// Total duration of the candidate experiment.
         /// <see cref="IExperiment{T}.Try(Func{T})" /> or <see cref="IExperimentAsync{T}.Try(Func{Task{T}})" />.
         /// </summary>
         public TimeSpan CandidateDuration { get; }
-        
+
         /// <summary>
-        /// Gets the name of the experiment that was observed.
+        /// Name of the experiment that was observed.
         /// </summary>
         public string Name { get; }
-     }
+
+        /// <summary>
+        /// Name of the method where the experiment that was performed.
+        /// </summary>
+        public string CallingMethodName { get; }
+    }
 }

--- a/src/Scientist/Scientist.cs
+++ b/src/Scientist/Scientist.cs
@@ -84,19 +84,5 @@ namespace GitHub
         {
             ObservationsToPublish.Add(observation);
         }
-
-        private static void RelayObservations(CancellationToken cancellationToken)
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                var observation = ObservationsToPublish.Take(cancellationToken);
-                Scientist.ObservationPublisher.Publish(observation);
-            }
-        }
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public static String GetCallingMethodName([CallerMemberName] string memberName = "")
-        {
-            return memberName;
-        }
     }
 }

--- a/src/Scientist/Scientist.cs
+++ b/src/Scientist/Scientist.cs
@@ -1,4 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Internals;
 using NullGuard;
@@ -11,15 +16,24 @@ namespace GitHub
     public static class Scientist
     {
         // TODO: Evaluate the distribution of Random and whether it's good enough.
-        static readonly Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);                                
+        static readonly Random _random = new Random(DateTimeOffset.UtcNow.Millisecond);
+
+        private static readonly BlockingCollection<Observation> ObservationsToPublish = new BlockingCollection<Observation>();
+        private static readonly Lazy<IQbservable<Observation>> SetupObservations = new Lazy<IQbservable<Observation>>(
+            () =>
+            {
+                var qbservations = ObservationsToPublish.ToObservable(TaskPoolScheduler.Default).AsQbservable();
+                qbservations.Subscribe((observation) => { ObservationPublisher.Publish(observation); });// So ObservationPublisher still works
+
+                return qbservations;
+
+            });
+
+        public static readonly IQbservable<Observation> Observations = SetupObservations.Value;
+
 
         // Should be configured once before starting observations.
-        // TODO: How can we guide the developer to the pit of success
-        public static IObservationPublisher ObservationPublisher
-        {
-            get;
-            set;
-        } = new InMemoryObservationPublisher();
+        public static IObservationPublisher ObservationPublisher { get; set; } = new InMemoryObservationPublisher();
 
         /// <summary>
         /// Conduct a synchronous experiment
@@ -27,14 +41,16 @@ namespace GitHub
         /// <typeparam name="T">The return type of the experiment</typeparam>
         /// <param name="name">Name of the experiment</param>
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
+       
         /// <returns>The value of the experiment's control function.</returns>
         [return: AllowNull]
-        public static T Science<T>(string name, Action<IExperiment<T>> experiment)
+        [MethodImpl(MethodImplOptions.NoInlining)] //So that we get the Source code CallerMemberName method name (may be lost when inlined in Release Mode).
+#pragma warning disable 1573
+        public static T Science<T>(string name, Action<IExperiment<T>> experiment, [CallerMemberName] string callingMethodName = "")
+#pragma warning restore 1573
         {
-            // TODO: Maybe we could automatically generate the name if none is provided using the calling method name. We'd have to 
-            // make sure we don't inline this method though.
-            var experimentBuilder = new Experiment<T>(name);
-            
+            var experimentBuilder = new Experiment<T>(name, callingMethodName);
+
             experiment(experimentBuilder);
 
             return experimentBuilder.Build().Run().Result;
@@ -48,13 +64,39 @@ namespace GitHub
         /// <param name="experiment">Experiment callback used to configure the experiment</param>
         /// <returns>The value of the experiment's control function.</returns>
         [return: AllowNull]
-        public static Task<T> ScienceAsync<T>(string name, Action<IExperimentAsync<T>> experiment)
+        [MethodImpl(MethodImplOptions.NoInlining)] //So that we get the Source code CallerMemberName method name (may be lost when inlined in Release Mode).
+#pragma warning disable 1573
+        public static Task<T> ScienceAsync<T>(string name, Action<IExperimentAsync<T>> experiment, [CallerMemberName] string callingMethodName = "")
+#pragma warning restore 1573
         {
-            var experimentBuilder = new Experiment<T>(name);
-            
+            var experimentBuilder = new Experiment<T>(name, callingMethodName);
+
             experiment(experimentBuilder);
 
             return experimentBuilder.Build().Run();
+        }
+
+        /// <summary>
+        /// Fast, fire and forget, publishing of Observations <see cref="Observation"/> .
+        /// </summary>
+        /// <param name="observation">Observation to publish</param>
+        public static void PublishObservation(Observation observation)
+        {
+            ObservationsToPublish.Add(observation);
+        }
+
+        private static void RelayObservations(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var observation = ObservationsToPublish.Take(cancellationToken);
+                Scientist.ObservationPublisher.Publish(observation);
+            }
+        }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static String GetCallingMethodName([CallerMemberName] string memberName = "")
+        {
+            return memberName;
         }
     }
 }

--- a/src/Scientist/Scientist.cs
+++ b/src/Scientist/Scientist.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using GitHub.Internals;
 using NullGuard;
@@ -23,7 +22,7 @@ namespace GitHub
             () =>
             {
                 var qbservations = ObservationsToPublish.ToObservable(TaskPoolScheduler.Default).AsQbservable();
-                qbservations.Subscribe((observation) => { ObservationPublisher.Publish(observation); });// So ObservationPublisher still works
+                qbservations.Subscribe(observation => { ObservationPublisher.Publish(observation); });// So ObservationPublisher still works
 
                 return qbservations;
 

--- a/src/Scientist/Scientist.csproj
+++ b/src/Scientist/Scientist.csproj
@@ -38,6 +38,26 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.5\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Linq, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Linq.2.2.5\lib\net45\System.Reactive.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reactive.Providers, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-Providers.2.2.5\lib\net45\System.Reactive.Providers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Scientist/packages.config
+++ b/src/Scientist/packages.config
@@ -2,4 +2,10 @@
 <packages>
   <package id="Fody" version="1.29.2" targetFramework="net452" developmentDependency="true" />
   <package id="NullGuard.Fody" version="1.4.5" targetFramework="net452" developmentDependency="true" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Providers" version="2.2.5" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Publishing of observations was essentially synchronous (as it was the last `await` before returning from an experiment). 

I have refactored the ` Scientist.PublishObservation()`  to use a, thread safe, `BlockingCollection` which is not `async` (not that it matters in this case). Blocking collections allow fast, thread safe, adds; which a consumer then blocks reading from until there is an item to process at the other end.

This did mean that using the `Scientist.ObservationPublisher` property stopped work properly. (but Ihave it working now) As the Experiment may have ended before the Observation had been published (which messed up a bunch of unit tests). This lead to race conditions where one unit test would be Asserting against another tests Observations.

I then implemented an `IQbservable<Observation>` property `Observations` this allows us to have multiple Observation subscribers with filtering! *Snazzy* Which then pipes back into`Scientist.ObservationPublisher`

Finally to allow unit-tests to find their own observations, I added a `CallingMethodName` property to the `Observation` Class  and infrastructure to automatically populate the method name of where an experiment was run from. That with the `TestHelper.ObservationsGeneratedInThisMethod()` a unit test's correct observations can be found.


Example:

``` cs

        [Fact]
        public async Task AllowsReturningNullFromControlOrTest()
        {
            var result = Scientist.Science<object>("failure", experiment =>
                {
                    experiment.Use(() => null);
                    experiment.Try(() => null);
                });

            Assert.Null(result);

            var observation = await TestHelper.ObservationsGeneratedInThisMethod().FirstAsync();

            Assert.True(observation.Success);
        }


```



