### PR TITLE
Updated result publishing to be fire and forget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ public Task Publish<T, TClean>(Result<T, TClean> result)
 }
 ```
 
+If you need to ensure that the scientist results are published prior to your program's exit use `Scientist.WhenPublished()`:+1:
+
+```csharp
+static async void MainAsync(string[] args)
+{
+    await RunProgram(args);
+
+    await Scientist.WhenPublished();
+}
+```
+
 By default observations are stored in an in-memory publisher. For production use, you'll
 probably want to implement an `IResultPublisher`.
 

--- a/src/Scientist/Internals/ConcurrentSet.cs
+++ b/src/Scientist/Internals/ConcurrentSet.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace GitHub.Internals
+{
+    internal class ConcurrentSet<T>
+    {
+        static readonly byte One = 1;
+        static readonly byte Zero = 0;
+
+        ConcurrentDictionary<T, byte> _dictionary = new ConcurrentDictionary<T, byte>();
+
+        public bool IsEmpty => _dictionary.IsEmpty;
+        public ICollection<T> Items => _dictionary.Keys;
+
+        public bool ContainsKey(T item) => _dictionary.ContainsKey(item);
+
+        public bool TryAdd(T item)
+        {
+            byte data = _dictionary.AddOrUpdate(
+                item,
+                Zero,
+                (key, value) => (byte)(value + One));
+
+            return data == Zero;
+        }
+
+        public bool TryRemove(T item)
+        {
+            byte _;
+            return _dictionary.TryRemove(item, out _);
+        }
+    }
+}

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -24,12 +24,14 @@ namespace GitHub.Internals
         private Func<Task<bool>> _runIf = _alwaysRun;
         private readonly List<Func<T, T, Task<bool>>> _ignores = new List<Func<T, T, Task<bool>>>();
         private readonly Dictionary<string, dynamic> _contexts = new Dictionary<string, dynamic>();
+        private readonly ConcurrentSet<Task> _publishingTasks;
 
-        public Experiment(string name, Func<Task<bool>> enabled)
+        public Experiment(string name, ConcurrentSet<Task> publishingTasks, Func<Task<bool>> enabled)
         {
             _name = name;
             _candidates = new Dictionary<string, Func<Task<T>>>();
             _enabled = enabled;
+            _publishingTasks = publishingTasks;
         }
 
         public bool ThrowOnMismatches { get; set; }
@@ -115,6 +117,7 @@ namespace GitHub.Internals
                 Enabled = _enabled,
                 Ignores = _ignores,
                 Name = _name,
+                PublishingTasks = _publishingTasks,
                 RunIf = _runIf,
                 Thrown = _thrown,
                 ThrowOnMismatches = ThrowOnMismatches

--- a/src/Scientist/Internals/ExperimentInstance.cs
+++ b/src/Scientist/Internals/ExperimentInstance.cs
@@ -96,7 +96,15 @@ namespace GitHub.Internals
                 // Disable the warning, because the task is being tracked on the set, 
                 // and immediately removed upon completion.
 #pragma warning disable CS4014
-                task.ContinueWith(_ => PublishingTasks.TryRemove(task));
+                task.ContinueWith(_ =>
+                {
+                    if (task.IsFaulted)
+                    {
+                        Thrown(Operation.Publish, task.Exception.GetBaseException());
+                    }
+
+                    PublishingTasks.TryRemove(task);
+                });
 #pragma warning restore CS4014
             }
             catch (Exception ex)

--- a/src/Scientist/Internals/ExperimentSettings.cs
+++ b/src/Scientist/Internals/ExperimentSettings.cs
@@ -21,6 +21,7 @@ namespace GitHub.Internals
         public Func<Task<bool>> Enabled { get; set; }
         public IEnumerable<Func<T, T, Task<bool>>> Ignores { get; set; }
         public string Name { get; set; }
+        public ConcurrentSet<Task> PublishingTasks { get; set; }
         public Func<Task<bool>> RunIf { get; set; }
         public bool ThrowOnMismatches { get; set; }
         public Action<Operation, Exception> Thrown { get; set; }

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -744,5 +744,52 @@ public class TheScientistClass
 
             mock.Received().Clean(expectedResult);
         }
+
+        [Fact]
+        public async Task FireAndForget()
+        {
+            const int expectedResult = 42;
+
+            // Create a new publisher that will delay all
+            // publishing to account for this test.
+            var publisher = Substitute.For<IResultPublisher>();
+            publisher.Publish(Arg.Any<Result<int, int>>())
+                .Returns(call => Task.Delay(100));
+
+            var mock = Substitute.For<IControlCandidate<int, string>>();
+            mock.Control().Returns(expectedResult);
+            mock.Candidate().Returns(expectedResult);
+
+            const int count = 10;
+            using (Swap.Publisher(publisher))
+            {
+                Parallel.ForEach(
+                    Enumerable.Repeat(0, count),
+                    src =>
+                    {
+                        var result = Scientist.Science<int>(nameof(FireAndForget), experiment =>
+                        {
+                            experiment.Use(mock.Control);
+                            experiment.Try(mock.Candidate);
+                        });
+
+                        Assert.Equal(expectedResult, result);
+                    });
+            }
+
+            // Make sure that the above science calls are still publishing.
+            Task whenPublished = Scientist.WhenPublished();
+            Assert.NotNull(whenPublished);
+
+            // Ensure that the mock was called before the when published task has completed.
+            mock.Received(count).Control();
+            mock.Received(count).Candidate();
+
+            Assert.False(whenPublished.IsCompleted, "When Published Task completed early.");
+
+            await whenPublished;
+
+            Assert.True(Scientist.WhenPublished().IsCompleted, "When Published Task isn't complete.");
+        }
     }
 }

--- a/test/Scientist.Test/ThrownTests.cs
+++ b/test/Scientist.Test/ThrownTests.cs
@@ -138,7 +138,7 @@ public class ThrownTests
 
         using (Swap.Publisher(publisher))
         {
-            int result = Scientist.Science<int>(nameof(PublishOperation), experiment =>
+            int result = Scientist.Science<int>(nameof(PublishAsyncOperation), experiment =>
             {
                 experiment.Thrown(mock.Thrown);
                 experiment.Use(mock.Control);


### PR DESCRIPTION
Added ConcurrentSet, which wraps up ConcurrentDictionary calls without needing TValue.
Updated ExperimentInstance to track publishing tasks as fire and forget to avoid publishing from blocking the result's return value.
Added tests to ensure that Science calls are not blocked by result publishing.