### PR TITLE
Remove account feed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ build_script:
 - cmd: build.cmd CreatePackages
 test: off
 nuget:
-    account_feed: true
     project_feed: true
 artifacts:
 - path: 'packaging\**\scientist*.nupkg'


### PR DESCRIPTION
According to http://help.appveyor.com/discussions/problems/6024-build-stalled-prompting-for-nuget-permissions this is a vulnerability for a public project.