### PR TITLE
Included information about the operation type that threw the exception.

### DIFF
--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -10,7 +10,7 @@ namespace GitHub.Internals
 
         private static readonly Func<Task<bool>> _alwaysRun = () => Task.FromResult(true);
         private static readonly Action<Operation, Exception> _alwaysThrow
-            = (operation, exception) => throw new OperationException(operation, exception);
+            = (operation, exception) => { throw new OperationException(operation, exception); };
 
         private string _name;
         private int _concurrentTasks;

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -10,25 +10,7 @@ namespace GitHub.Internals
 
         private static readonly Func<Task<bool>> _alwaysRun = () => Task.FromResult(true);
         private static readonly Action<Operation, Exception> _alwaysThrow
-            = (operation, exception) =>
-            {
-                string exceptionMessage;
-                switch (operation)
-                {
-                    case Operation.Clean:
-                    case Operation.Compare:
-                    case Operation.Enabled:
-                    case Operation.Ignore:
-                    case Operation.Publish:
-                    case Operation.RunIf:
-                        exceptionMessage = $"An exception occurred within the experiment during the '{operation.ToString()}' operation.";
-                        break;
-                    default:
-                        exceptionMessage = "An exception occurred within the experiment, the operation was unknown.";
-                        break;
-                }
-                throw new Exception(exceptionMessage, exception);
-            };
+            = (operation, exception) => throw new OperationException(operation, exception);
 
         private string _name;
         private int _concurrentTasks;

--- a/src/Scientist/Internals/Experiment.cs
+++ b/src/Scientist/Internals/Experiment.cs
@@ -10,7 +10,25 @@ namespace GitHub.Internals
 
         private static readonly Func<Task<bool>> _alwaysRun = () => Task.FromResult(true);
         private static readonly Action<Operation, Exception> _alwaysThrow
-            = (operation, exception) => { throw exception; };
+            = (operation, exception) =>
+            {
+                string exceptionMessage;
+                switch (operation)
+                {
+                    case Operation.Clean:
+                    case Operation.Compare:
+                    case Operation.Enabled:
+                    case Operation.Ignore:
+                    case Operation.Publish:
+                    case Operation.RunIf:
+                        exceptionMessage = $"An exception occurred within the experiment during the '{operation.ToString()}' operation.";
+                        break;
+                    default:
+                        exceptionMessage = "An exception occurred within the experiment, the operation was unknown.";
+                        break;
+                }
+                throw new Exception(exceptionMessage, exception);
+            };
 
         private string _name;
         private int _concurrentTasks;

--- a/src/Scientist/OperationException.cs
+++ b/src/Scientist/OperationException.cs
@@ -20,7 +20,7 @@ namespace GitHub
         private static string GetExceptionMessage(Operation operation)
         {
             string exceptionMessage = Enum.IsDefined(typeof(Operation), operation)
-                ? $"An exception occurred within the experiment during the '{operation}' operation. Consider checking both the inner exception and the {nameof(Operation)} property for details on this exception."
+                ? $"An exception occurred within the experiment during the '{operation}' operation. Consider checking both the {nameof(InnerException)} and the {nameof(Operation)} properties for details on this exception."
                 : "An exception occurred within the experiment, the operation was unknown. The operation should never be unknown, please report this.";
             return exceptionMessage;
         }

--- a/src/Scientist/OperationException.cs
+++ b/src/Scientist/OperationException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace GitHub
+{
+    /// <summary>
+    /// Thrown when an exception was thrown during the execution of an operation.
+    /// </summary>
+    public class OperationException : Exception
+    {
+        /// <summary>
+        /// The operation in which this exception occurred within.
+        /// </summary>
+        public Operation Operation { get; }
+
+        public override string Message { get; }
+
+        internal OperationException(Operation operation, Exception inner) : base(null, inner)
+        {
+            Operation = operation;
+            Message = GetExceptionMessage(operation);
+        }
+
+        private static string GetExceptionMessage(Operation operation)
+        {
+            string exceptionMessage = Enum.IsDefined(typeof(Operation), operation)
+                ? $"An exception occurred within the experiment during the '{operation}' operation. Consider checking both the inner exception and the {nameof(Operation)} property for details on this exception."
+                : "An exception occurred within the experiment, the operation was unknown. The operation should never be unknown, please report this.";
+            return exceptionMessage;
+        }
+    }
+}

--- a/src/Scientist/OperationException.cs
+++ b/src/Scientist/OperationException.cs
@@ -12,12 +12,9 @@ namespace GitHub
         /// </summary>
         public Operation Operation { get; }
 
-        public override string Message { get; }
-
-        internal OperationException(Operation operation, Exception inner) : base(null, inner)
+        internal OperationException(Operation operation, Exception inner) : base(GetExceptionMessage(operation), inner)
         {
             Operation = operation;
-            Message = GetExceptionMessage(operation);
         }
 
         private static string GetExceptionMessage(Operation operation)

--- a/test/Scientist.Test/ThrownTests.cs
+++ b/test/Scientist.Test/ThrownTests.cs
@@ -140,4 +140,29 @@ public class ThrownTests
         Assert.Equal(expectedResult, result);
         mock.Received().Thrown(Operation.RunIf, ex);
     }
+
+    [Fact]
+    public void DefaultThrow()
+    {
+        var mock = Substitute.For<IControlCandidate<int>>();
+
+        var ex = new Exception();
+
+        Action action = () => Scientist.Science<int>(nameof(DefaultThrow), experiment =>
+        {
+            experiment.Compare((x, y) =>
+            {
+                throw ex;
+            });
+            experiment.Use(mock.Control);
+            experiment.Try(mock.Candidate);
+        });
+
+        var exception = Assert.Throws<AggregateException>(action);
+        var operationException = Assert.IsType<OperationException>(exception.InnerException);
+        Assert.Equal(Operation.Compare, operationException.Operation);
+
+        var actualException = Assert.IsType<Exception>(operationException.InnerException);
+        Assert.Equal(ex, actualException);
+    }
 }


### PR DESCRIPTION
When an error occurs within the publisher (and other locations), to a new developer, the stack trace may be confusing, e.g.

```
System.AggregateException: One or more errors occurred. ---> System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at GitHub.Internals.Experiment`2.<>c.<.cctor>b__39_1(Operation operation, Exception exception)
   at GitHub.Internals.ExperimentInstance`2.<Run>d__15.MoveNext()
```

This pull includes additional information when exceptions are thrown using default configurations.