### PR TITLE
fixes #99 - only throw inner exception for AggregateExceptions

### DIFF
--- a/src/Scientist/Observation.cs
+++ b/src/Scientist/Observation.cs
@@ -121,9 +121,13 @@ namespace GitHub
             {
                 Value = await block();
             }
-            catch (Exception ex)
+            catch (AggregateException ex)
             {
                 Exception = ex.GetBaseException();
+            }
+            catch (Exception ex)
+            {
+                Exception = ex;
             }
             stopwatch.Stop();
 

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -71,7 +71,7 @@ public class TheScientistClass
             var candidateException = new InvalidOperationException(null, new Exception());
             mock.Control().Returns(x => { throw controlException; return Task.FromResult(0); });
             mock.Candidate().Returns(x => { throw controlException; return Task.FromResult(0); });
-            const string experimentName = nameof(RunsBothBranchesOfTheExperimentAndMatchesExceptions);
+            const string experimentName = nameof(RunsBothBranchesOfTheExperimentAndThrowsCorrectInnerException);
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {

--- a/test/Scientist.Test/ScientistTests.cs
+++ b/test/Scientist.Test/ScientistTests.cs
@@ -64,6 +64,26 @@ public class TheScientistClass
         }
 
         [Fact]
+        public async Task RunsBothBranchesOfTheExperimentAndThrowsCorrectInnerException()
+        {
+            var mock = Substitute.For<IControlCandidate<Task<int>>>();
+            var controlException = new InvalidOperationException(null, new Exception());
+            var candidateException = new InvalidOperationException(null, new Exception());
+            mock.Control().Returns(x => { throw controlException; return Task.FromResult(0); });
+            mock.Candidate().Returns(x => { throw controlException; return Task.FromResult(0); });
+            const string experimentName = nameof(RunsBothBranchesOfTheExperimentAndMatchesExceptions);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await Scientist.ScienceAsync<int>(experimentName, experiment =>
+                {
+                    experiment.Use(mock.Control);
+                    experiment.Try("candidate", mock.Candidate);
+                });
+            });
+        }
+
+        [Fact]
         public void RunsBothBranchesOfTheExperimentAndReportsSuccess()
         {
             var mock = Substitute.For<IControlCandidate<int>>();


### PR DESCRIPTION
Tried to add a test, but since the tests were all synchronous, everything got wrapped in AggregateException no matter what I did.