### PR TITLE
Added AllocatedBytes metrics to Observations

### DIFF
--- a/src/Scientist/Internals/GCHelper.cs
+++ b/src/Scientist/Internals/GCHelper.cs
@@ -1,0 +1,132 @@
+﻿namespace GitHub.Internals
+{
+    using System;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+
+    internal static class GCHelper
+    {
+        private const string DebugConfigurationName = "DEBUG";
+        internal const string ReleaseConfigurationName = "RELEASE";
+        internal const string Unknown = "?";
+
+        public static bool IsMono { get; } = Type.GetType("Mono.Runtime") != null;
+
+        public static bool IsFullFramework =>
+#if (NET451)
+            true;
+#else
+            System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+#endif
+
+        public static bool IsNetCore =>
+#if (NET451)
+            false;
+#else
+            System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
+#endif
+
+        private static long AllocationQuantum { get; } = CalculateAllocationQuantumSize();
+
+        private static readonly Func<long> GetAllocatedBytesForCurrentThreadDelegate = GetAllocatedBytesForCurrentThread();
+
+        /// <summary>
+        /// returns total allocated bytes (not per operation)
+        /// </summary>
+        /// <param name="excludeAllocationQuantumSideEffects">Allocation quantum can affecting some of our nano-benchmarks in non-deterministic way.
+        /// when this parameter is set to true and the number of all allocated bytes is less or equal AQ, we ignore AQ and put 0 to the results</param>
+        /// <returns></returns>
+        public static long GetAllocatedBytes()
+        {
+            var allocation = GetAllocatedBytesByRuntime();
+
+            if (IsNetCore)
+            {
+                return allocation;
+            }
+
+            return allocation <= AllocationQuantum ? 0L : allocation;
+        }
+
+        private static long GetAllocatedBytesByRuntime()
+        {
+            // Monitoring is not available in Mono, see http://stackoverflow.com/questions/40234948/how-to-get-the-number-of-allocated-bytes-
+            if (IsMono)
+            {
+                return 0;
+            }
+            //GC.Collect();
+
+#if (NET451)
+            // "This instance Int64 property returns the number of bytes that have been allocated by a specific 
+            // AppDomain. The number is accurate as of the last garbage collection." - CLR via C#
+            // so we enforce GC.Collect here just to make sure we get accurate results
+            return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+#elif (NETSTANDARD2_0)
+            // it can be a .NET app consuming our .NET Standard package
+            if (IsFullFramework) 
+            {
+                GC.Collect();
+                return AppDomain.CurrentDomain.MonitoringTotalAllocatedMemorySize;
+            }
+            // https://apisof.net/catalog/System.GC.GetAllocatedBytesForCurrentThread() is not part of the .NET Standard, so we use reflection to call it..
+            return GetAllocatedBytesForCurrentThreadDelegate.Invoke();
+#elif (NETCOREAPP2_1)
+            // but CoreRT does not support the reflection yet, so only because of that we have to target .NET Core 2.1
+            // to be able to call this method without reflection and get MemoryDiagnoser support for CoreRT ;)
+            return GC.GetAllocatedBytesForCurrentThread();
+#else
+            return 0;
+#endif
+        }
+
+        private static Func<long> GetAllocatedBytesForCurrentThread()
+        {
+            // for some versions of .NET Core this method is internal, 
+            // for some public and for others public and exposed ;)
+#if (NETSTANDARD2_0 || NETCOREAPP2_1)
+            var method = typeof(GC)
+                            .GetTypeInfo()
+                            .GetMethod("GetAllocatedBytesForCurrentThread",
+                            BindingFlags.Public | BindingFlags.Static)
+                         ?? typeof(GC)
+                            .GetTypeInfo()
+                            .GetMethod("GetAllocatedBytesForCurrentThread",
+                            BindingFlags.NonPublic | BindingFlags.Static);
+            return () => (long)method.Invoke(null, null);
+#else
+            return () => 0L;
+#endif
+        }
+
+        /// <summary>
+        /// code copied from https://github.com/rsdn/CodeJam/blob/71a6542b6e5c52ea8dd92c601adad11e62796a98/PerfTests/src/%5BL4_Configuration%5D/Metrics/%5BMetricValuesProvider%5D/GcMetricValuesProvider.cs#L63-L89
+        /// </summary>
+        /// <returns></returns>
+        private static long CalculateAllocationQuantumSize()
+        {
+            long result;
+            int retry = 0;
+            do
+            {
+                if (++retry > 10)
+                {
+                    // 8kb https://github.com/dotnet/coreclr/blob/master/Documentation/botr/garbage-collection.md
+                    result = 8192;
+                    break;
+                }
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                result = GC.GetTotalMemory(false);
+                var tmp = new object();
+                result = GC.GetTotalMemory(false) - result;
+                GC.KeepAlive(tmp);
+            } while (result <= 0);
+
+            return result;
+        }
+    }
+}

--- a/src/Scientist/Scientist.csproj
+++ b/src/Scientist/Scientist.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <Description>scientist</Description>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <Authors>Github</Authors>
-    <TargetFrameworks>netstandard1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Scientist</AssemblyName>
     <PackageId>Scientist</PackageId>
     <Authors>GitHub</Authors>
@@ -34,8 +34,9 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
@@ -53,7 +54,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-62925-02" PrivateAssets="All" />
   </ItemGroup>
-
+  
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/test/Scientist.Benchmark/Scientist.Benchmark.csproj
+++ b/test/Scientist.Benchmark/Scientist.Benchmark.csproj
@@ -3,8 +3,10 @@
     <Description>Benchmarks for scientist</Description>
     <OutputType>Exe</OutputType>
     <RootNamespace>GitHub</RootNamespace>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Scientist\Scientist.csproj" />
   </ItemGroup>

--- a/test/Scientist.Test/Scientist.Test.csproj
+++ b/test/Scientist.Test/Scientist.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Scientist.Test</AssemblyName>
     <PackageId>Scientist.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
Hi, 

I quite like the idea of Scientist.Net, as I often don't want to set up a full Benchmark.Net run. However I found the lack of memory allocation information a bit of showstopper.   

This Pull Request adds a new `AllocatedBytes `field to Observation. To enable this to work cross runtime I've cribbed a lot of the hackery from Benchmark.Net's implementation (Garbage Collection tooling is wildly inconsistent - see the last paragraph). Included are a test for the basic functionality and one that asserts that Scientist's own allocations don't appear in the results. Note that I did not include the Generation collection counts because it was trivially easy to get miscounts with the way Scientist.Net works versus Benchmark.Net's dedicated runs.

I also upped the versions of the Nuget package (for my testing), the Core SDK (for the exe/unit tests) so they used the latest GC Tooling. You can revert these changes and the code will still work.

In terms of impact of adding this behaviour. For .Net Core it is almost imperceptible, for .Net Framework the only way to achieve this functionality is with `GC.Collect`s which is a little more invasive. I would say that the benefit of seeing allocations outweighs the downsides, especially since allocations are more consistent than times for Scientist's kind of micro-benchmarking. 

Lastly I've [proposed an addition to vNext of .Net Standard](https://github.com/dotnet/standard/issues/771) that would do away with all the hackery for both this, Benchmark.Net and anyone else who cares about allocations at runtime.  

### Commit notes

```
Added target for .Net Standard 2.0 to detect better GC tooling
Added test for new AllocatedBytes feature
Added test to account for Scientist's own allocations in AllocatedBytes
Upgraded test and console app to netcoreapp 2.1 to use new GC Tooling
Some portions of GCHelper were derived from Benchmark.Net and are used under license
```